### PR TITLE
use uname to simplify getting kernel version

### DIFF
--- a/sign-kernel.sh
+++ b/sign-kernel.sh
@@ -4,8 +4,8 @@ set -ouex pipefail
 
 kernel_version=""
 
-if command -v rpm; then
-  kernel_version=$(rpm -qa | grep -P 'kernel-(|surface-)(\d+\.\d+\.\d+)' | sed -E 's/kernel-(|surface-)//')
+if command -v uname; then
+  kernel_version=$(uname -r)
 fi
 
 if command -v rpm-ostree; then


### PR DESCRIPTION
Using `uname -r` gets the same output but allows for alternative kernels that might be named differently, for example [`kernel-cachyos`](https://copr.fedorainfracloud.org/coprs/bieszczaders/kernel-cachyos/).

It's also simpler which should make it more robust if package names or versioning schemes change.