### PR TITLE
Add ability to sign alternate kernels

### DIFF
--- a/kernel_options.txt
+++ b/kernel_options.txt
@@ -1,0 +1,5 @@
+surface
+cachyos
+cachyos-lts
+cachyos-rt
+lqx

--- a/sign-kernel.sh
+++ b/sign-kernel.sh
@@ -3,9 +3,10 @@
 set -ouex pipefail
 
 kernel_version=""
+alt_kernels=$(sed 's/$/-/' kernel_options.txt | paste -sd'|')
 
 if command -v rpm; then
-  kernel_version=$(rpm -qa | grep -P 'kernel-(|surface-)(\d+\.\d+\.\d+)' | sed -E 's/kernel-(|surface-)//')
+  kernel_version=$(rpm -qa | grep -P "kernel-(|$alt_kernels)(\d+\.\d+\.\d+)" | sed -E "s/kernel-(|$alt_kernels)//")
 fi
 
 if command -v rpm-ostree; then


### PR DESCRIPTION
This adds a text file with alternate kernel names. These are read into the bash script and concatenated to fit the regex pattern. Implementation of the list and how it's read/concatenated could be changed, I just went simple with the text file.