### PR TITLE
Check if EXISTING_SIGNATURES is empty before removing signatures

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image_name: [kernel-signer-test]
+        image_name: [kernel-signer-test, kernel-signer-test-cachyos]
     steps:
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action

--- a/Containerfile
+++ b/Containerfile
@@ -3,3 +3,18 @@ FROM ghcr.io/ublue-os/base-main:latest AS kernel-signer-test
 COPY certs/ /etc/pki/kernel/
 
 RUN ostree container commit
+
+FROM kernel-signer-test AS kernel-signer-test-cachyos
+
+RUN wget https://copr.fedorainfracloud.org/coprs/bieszczaders/kernel-cachyos/repo/fedora-$(rpm -E %fedora)/bieszczaders-kernel-cachyos-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_cachyos_kernel.repo && \
+    rpm-ostree cliwrap install-to-root / && \
+    rpm-ostree override remove \
+        kernel \
+        kernel-core \
+        kernel-modules \
+        kernel-modules-core \
+        kernel-modules-extra \
+        --install \
+        kernel-cachyos
+
+RUN ostree container commit

--- a/sign-kernel.sh
+++ b/sign-kernel.sh
@@ -52,9 +52,8 @@ echo "Signing kernel..."
 CRT_PATH=$(echo $(dirname "$PUBKEY_PATH")/public_key.crt)
 
 openssl x509 -in $PUBKEY_PATH -out $CRT_PATH
-EXISTING_SIGNATURES="$(sbverify --list /usr/lib/modules/$kernel_version/vmlinuz)"
+EXISTING_SIGNATURES="$(sbverify --list /usr/lib/modules/$kernel_version/vmlinuz | grep '^signature \([0-9]\+\)$' | sed 's/^signature \([0-9]\+\)$/\1/')" || true
 if [[ -n $EXISTING_SIGNATURES ]]; then
-  EXISTING_SIGNATURES="$(echo $EXISTING_SIGNATURES | grep '^signature \([0-9]\+\)$' | sed 's/^signature \([0-9]\+\)$/\1/')"
   for SIGNUM in $EXISTING_SIGNATURES
   do
     echo "Found existing signature at signum $SIGNUM, removing..."

--- a/sign-kernel.sh
+++ b/sign-kernel.sh
@@ -52,12 +52,15 @@ echo "Signing kernel..."
 CRT_PATH=$(echo $(dirname "$PUBKEY_PATH")/public_key.crt)
 
 openssl x509 -in $PUBKEY_PATH -out $CRT_PATH
-EXISTING_SIGNATURES="$(sbverify --list /usr/lib/modules/$kernel_version/vmlinuz | grep '^signature \([0-9]\+\)$' | sed 's/^signature \([0-9]\+\)$/\1/')"
-for SIGNUM in $EXISTING_SIGNATURES
-do
-  echo "Found existing signature at signum $SIGNUM, removing..."
-  sbattach --remove /usr/lib/modules/$kernel_version/vmlinuz
-done
+EXISTING_SIGNATURES="$(sbverify --list /usr/lib/modules/$kernel_version/vmlinuz)"
+if [[ -n $EXISTING_SIGNATURES ]]; then
+  EXISTING_SIGNATURES="$(echo $EXISTING_SIGNATURES | grep '^signature \([0-9]\+\)$' | sed 's/^signature \([0-9]\+\)$/\1/')"
+  for SIGNUM in $EXISTING_SIGNATURES
+  do
+    echo "Found existing signature at signum $SIGNUM, removing..."
+    sbattach --remove /usr/lib/modules/$kernel_version/vmlinuz
+  done
+fi
 sbsign --cert $CRT_PATH --key $PRIVKEY_PATH /usr/lib/modules/$kernel_version/vmlinuz --output /usr/lib/modules/$kernel_version/vmlinuz
 sbverify --list /usr/lib/modules/$kernel_version/vmlinuz
 


### PR DESCRIPTION
This prevents the script from failing from a failed grep when EXISTING_SIGNATURES is empty, which is the case for non-standard, unsigned kernel packages.

Also added another test with an image using the CachyOS copr package. Happy to consider a different alternative kernel installation, maybe if there's an official -rt one or something? But that's probably signed already?