### PR TITLE
fix(sign-kernel): Properly substitute kernel_suffix value

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image_name: [kernel-signer-test]
+        image_name: [kernel-signer-test, kernel-signer-test-surface]
     steps:
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action
@@ -81,10 +81,20 @@ jobs:
           extra-args: |
             --target=${{ matrix.image_name }}
 
-      # Test kernel signing
-      - name: Sign kernel
+      # Test signing default kernel
+      - name: Sign default kernel
+        if: matrix.image_name == 'kernel-signer-test'
         uses: ./
         with:
+          image: ${{ steps.build_image.outputs.image }}
+          tags: ${{ steps.generate-tags.outputs.alias_tags }}
+
+      # Test signing surface kernel
+      - name: Sign surface kernel
+        if: matrix.image_name == 'kernel-signer-test-surface'
+        uses: ./
+        with:
+          kernel_suffix: surface
           image: ${{ steps.build_image.outputs.image }}
           tags: ${{ steps.generate-tags.outputs.alias_tags }}
 

--- a/Containerfile
+++ b/Containerfile
@@ -3,3 +3,21 @@ FROM ghcr.io/ublue-os/base-main:latest AS kernel-signer-test
 COPY certs/ /etc/pki/kernel/
 
 RUN ostree container commit
+
+FROM kernel-signer-test AS kernel-signer-test-surface
+
+RUN wget -O /etc/yum.repos.d/linux-surface.repo \
+    https://pkg.surfacelinux.com/fedora/linux-surface.repo && \
+    wget https://github.com/linux-surface/linux-surface/releases/download/silverblue-20201215-1/kernel-20201215-1.x86_64.rpm && \
+    rpm-ostree override replace ./*.rpm \
+	    --remove kernel-core \
+	    --remove kernel-modules \
+	    --remove kernel-modules-extra \
+        --remove libwacom \
+        --remove libwacom-data \
+	    --install kernel-surface \
+	    --install iptsd \
+        --install libwacom-surface \
+        --install libwacom-surface-data
+
+RUN ostree container commit

--- a/sign-kernel.sh
+++ b/sign-kernel.sh
@@ -5,7 +5,7 @@ set -ouex pipefail
 kernel_version=""
 
 if command -v rpm; then
-  kernel_version=$(rpm -qa | grep -P 'kernel-(|$KERNEL_SUFFIX-)(\d+\.\d+\.\d+)' | sed -E 's/kernel-(|$KERNEL_SUFFIX-)//')
+  kernel_version=$(rpm -qa | grep -P 'kernel-(|'"$KERNEL_SUFFIX"'-)(\d+\.\d+\.\d+)' | sed -E 's/kernel-(|'"$KERNEL_SUFFIX"'-)//')
 fi
 
 if command -v rpm-ostree; then


### PR DESCRIPTION
Single quotes were preventing the kernel suffix from properly expanding.

Also added a test for signing the surface kernel.